### PR TITLE
feat: bare-clone worktree helpers

### DIFF
--- a/bin/git-clone-bare-for-worktrees
+++ b/bin/git-clone-bare-for-worktrees
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: git clone-bare-for-worktrees <url> [<name>]" >&2
+    exit 1
+fi
+
+url=$1
+basename=${url##*/}
+name=${2:-${basename%.*}}
+
+if [[ ! "$name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "Error: Invalid project name '$name'" >&2
+    echo "Name must contain only alphanumeric characters, dots, hyphens, and underscores" >&2
+    exit 1
+fi
+
+if [ -d "$name" ]; then
+    echo "Error: Directory '$name' already exists" >&2
+    exit 1
+fi
+
+mkdir "$name"
+cd "$name"
+
+# Clone as bare into a hidden .bare directory
+git clone --bare "$url" .bare
+
+# Create a .git file that points to .bare
+echo "gitdir: ./.bare" > .git
+
+# Fix the fetch config (bare clones don't set this up)
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+
+# Fetch all remote branches
+git fetch origin
+
+# Now create your worktrees
+git worktree add main

--- a/bin/wt
+++ b/bin/wt
@@ -1,220 +1,194 @@
-#!/bin/bash
-#
-# wt - git worktree wrapper that manages worktrees in .worktrees/ by default
+#!/usr/bin/env bash
+set -euo pipefail
+
+# wt - git worktree manager for bare-clone layouts
 #
 # Usage:
-#   wt add <branch> [<start-point>]  - Create worktree (creates branch if needed)
-#   wt ls                            - List all worktrees
-#   wt rm <branch>                   - Remove a worktree
-#   wt cd <branch>                   - Change to worktree directory
-#   wt path <branch>                 - Show path to a worktree
-#   wt prune                         - Clean up stale worktree references
-#   wt <any-other-git-worktree-cmd>  - Pass through to git worktree
+#   wt                            List all worktrees
+#   wt ls                         List all worktrees
+#   wt main                       Enter main/ worktree (creates if needed)
+#   wt add <name> [<start-point>] Create <name>/ worktree (default: origin/main)
+#   wt rm <name> [--keep-branch]  Remove worktree and delete local branch
+#   wt cd <name>                  Enter a worktree by directory name
+#   wt path <name>                Show path to a worktree
+#   wt prune                      Clean up stale worktree references
+#   wt help                       Show this help
 #
-# Examples:
-#   wt add feature/new-api           - Creates .worktrees/feature-new-api (new branch)
-#   wt add main                      - Creates .worktrees/main (existing branch)
-#   wt add fix-bug origin/main       - Creates new branch from origin/main
-#   wt cd feature/new-api            - Change to worktree directory
-#   wt rm feature/new-api            - Removes the worktree
-#   wt ls                            - Shows all worktrees
-#
-# Tips:
-#   - Branch names with slashes (feature/foo) become directories (feature-foo)
-#   - 'wt cd' uses a shell function wrapper (in zsh/bostonaholic.plugin.zsh)
-#   - Automatically detects if branch exists or needs to be created
+# Requires a bare-clone layout created by 'git clone-bare-for-worktrees'.
+# All worktrees are siblings of .bare/ in the project root.
 
-set -eu -o pipefail
+# Find project root by walking up from cwd looking for .bare/ + .git pointer.
+find_project_root() {
+    local dir="$PWD"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.bare" ] && [ -f "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
 
-# Get the git repository root (main repo, not worktree)
-get_repo_root() {
-    # Get the common git directory, then go up one level to get repo root
-    local git_common_dir
-    git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-    if [ -n "$git_common_dir" ]; then
-        # Remove the /.git suffix to get the repo root
-        dirname "$git_common_dir"
+require_bare_layout() {
+    local root
+    if ! root=$(find_project_root); then
+        echo "Error: Not in a bare-clone worktree layout." >&2
+        echo "Set up a project with: git clone-bare-for-worktrees <url>" >&2
+        exit 1
     fi
+    echo "$root"
 }
 
-# Convert branch name to a safe directory name
-# feature/new-api -> feature-new-api
-sanitize_branch_name() {
-    echo "$1" | sed 's/[\/:]/-/g'
+cmd_main() {
+    local root
+    root=$(require_bare_layout)
+    local worktree_dir="$root/main"
+
+    if [ ! -d "$worktree_dir" ]; then
+        git -C "$root" worktree add main main 2>/dev/null \
+            || git -C "$root" worktree add main
+    fi
+
+    echo "$worktree_dir"
 }
 
-# Get the worktree directory for a branch
-get_worktree_dir() {
-    local branch="$1"
-    local repo_root
-    repo_root=$(get_repo_root)
-    local sanitized
-    sanitized=$(sanitize_branch_name "$branch")
-    echo "${repo_root}/.worktrees/${sanitized}"
-}
-
-# Command: wt add <branch> [<start-point>]
-# Automatically creates branch if it doesn't exist, or uses existing branch
 cmd_add() {
     if [ $# -lt 1 ]; then
-        echo "Usage: wt add <branch> [<start-point>]" >&2
+        echo "Usage: wt add <name> [<start-point>]" >&2
         exit 1
     fi
 
-    local branch="$1"
+    local name="$1"
     shift
-    local start_point="${1:-}"
+    local start_point="${1:-origin/main}"
 
-    local worktree_dir
-    worktree_dir=$(get_worktree_dir "$branch")
+    local root
+    root=$(require_bare_layout)
+    local worktree_dir="$root/$name"
 
-    # Create .worktrees directory if it doesn't exist
-    local repo_root
-    repo_root=$(get_repo_root)
-    mkdir -p "${repo_root}/.worktrees"
-
-    # Check if branch exists (locally or remotely)
-    local branch_exists=false
-    if git show-ref --verify --quiet "refs/heads/${branch}" || \
-       git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
-        branch_exists=true
+    if [ -d "$worktree_dir" ]; then
+        echo "Worktree already exists: $name" >&2
+        echo "$worktree_dir"
+        return 0
     fi
 
-    # Build git worktree add command
-    local cmd=(git worktree add)
-
-    # If branch doesn't exist, add -b flag to create it
-    if [ "$branch_exists" = false ]; then
-        cmd+=(-b "$branch")
+    # Check if branch exists locally or on remote
+    if git -C "$root" show-ref --verify --quiet "refs/heads/$name" \
+        || git -C "$root" show-ref --verify --quiet "refs/remotes/origin/$name"; then
+        git -C "$root" worktree add "$worktree_dir" "$name"
+    else
+        git -C "$root" worktree add -b "$name" "$worktree_dir" "$start_point"
     fi
 
-    # Add the path
-    cmd+=("$worktree_dir")
-
-    # For existing branches, add branch name
-    if [ "$branch_exists" = true ]; then
-        cmd+=("$branch")
-    fi
-
-    # Add start point if provided
-    if [ -n "$start_point" ]; then
-        cmd+=("$start_point")
-    fi
-
-    # Execute
-    "${cmd[@]}"
-
-    echo
-    echo "Worktree created at: $worktree_dir"
-    echo "To switch to it: cd $worktree_dir"
+    echo "$worktree_dir"
 }
 
-# Command: wt list
-cmd_list() {
-    git worktree list "$@"
-}
+cmd_rm() {
+    local keep_branch=false
+    local name=""
 
-# Command: wt remove <branch> [options]
-cmd_remove() {
-    if [ $# -lt 1 ]; then
-        echo "Usage: wt remove <branch> [options]" >&2
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --keep-branch) keep_branch=true; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *)  name="$1"; shift ;;
+        esac
+    done
+
+    if [ -z "$name" ]; then
+        echo "Usage: wt rm <name> [--keep-branch]" >&2
         exit 1
     fi
 
-    local branch="$1"
-    shift
-    local worktree_dir
-    worktree_dir=$(get_worktree_dir "$branch")
+    if [ "$name" = "main" ]; then
+        echo "Error: Cannot remove persistent worktree 'main'." >&2
+        exit 1
+    fi
+
+    local root
+    root=$(require_bare_layout)
+    local worktree_dir="$root/$name"
 
     if [ ! -d "$worktree_dir" ]; then
-        echo "Worktree not found: $worktree_dir" >&2
-        echo "Available worktrees:" >&2
-        git worktree list >&2
+        echo "Worktree not found: $name" >&2
+        git -C "$root" worktree list >&2
         exit 1
     fi
 
-    # Remove the worktree
-    git worktree remove "$@" "$worktree_dir"
+    git -C "$root" worktree remove "$worktree_dir"
 
-    # Delete the local branch if it exists
-    if git show-ref --verify --quiet "refs/heads/${branch}"; then
-        echo "Deleting local branch: $branch"
-        git branch -D "$branch"
+    if [ "$keep_branch" = false ]; then
+        if git -C "$root" show-ref --verify --quiet "refs/heads/$name"; then
+            echo "Deleting local branch: $name"
+            git -C "$root" branch -D "$name"
+        fi
     fi
+
+    git -C "$root" worktree prune
 }
 
-# Command: wt prune
-cmd_prune() {
-    git worktree prune "$@"
-}
-
-# Command: wt path <branch>
-cmd_path() {
+cmd_cd() {
     if [ $# -lt 1 ]; then
-        echo "Usage: wt path <branch>" >&2
+        echo "Usage: wt cd <name>" >&2
         exit 1
     fi
 
-    local branch="$1"
-    local worktree_dir
-    worktree_dir=$(get_worktree_dir "$branch")
+    local name="$1"
+    local root
+    root=$(require_bare_layout)
+    local worktree_dir="$root/$name"
 
     if [ ! -d "$worktree_dir" ]; then
-        echo "Worktree not found: $worktree_dir" >&2
+        echo "Worktree not found: $name" >&2
         exit 1
     fi
 
     echo "$worktree_dir"
 }
 
-# Command: wt cd <branch>
-# Prints path to worktree (shell function wrapper handles actual cd)
-cmd_cd() {
-    if [ $# -lt 1 ]; then
-        echo "Usage: wt cd <branch>" >&2
-        exit 1
-    fi
-
-    local branch="$1"
-    local worktree_dir
-    worktree_dir=$(get_worktree_dir "$branch")
-
-    # Check if this worktree exists
-    if [ ! -d "$worktree_dir" ]; then
-        # Maybe it's the main repo? Check all worktrees to find where this branch is
-        local repo_root
-        repo_root=$(get_repo_root)
-        local found_path
-        found_path=$(git worktree list --porcelain | awk -v branch="$branch" '
-            /^worktree / { path = substr($0, 10) }
-            /^branch / {
-                br = substr($0, 8)
-                gsub(/^refs\/heads\//, "", br)
-                if (br == branch) { print path; exit }
-            }
-        ')
-
-        if [ -n "$found_path" ] && [ -d "$found_path" ]; then
-            echo "$found_path"
-        else
-            echo "Worktree not found: $worktree_dir" >&2
-            exit 1
-        fi
-    else
-        # Print the path (shell function wrapper in zsh plugin uses this)
-        echo "$worktree_dir"
-    fi
+cmd_path() {
+    cmd_cd "$@"
 }
 
-# Main command dispatcher
-main() {
-    # Check if we're in a git repository
-    if ! git rev-parse --git-dir >/dev/null 2>&1; then
-        echo "Error: Not in a git repository" >&2
-        exit 1
-    fi
+cmd_list() {
+    local root
+    root=$(require_bare_layout)
+    git -C "$root" worktree list "$@"
+}
 
-    # If no arguments, default to list
+cmd_prune() {
+    local root
+    root=$(require_bare_layout)
+    git -C "$root" worktree prune "$@"
+}
+
+cmd_help() {
+    cat <<'EOF'
+wt - git worktree manager for bare-clone layouts
+
+Usage:
+  wt                            List all worktrees
+  wt ls                         List all worktrees
+  wt main                       Enter main/ worktree (creates if needed)
+  wt add <name> [<start-point>] Create <name>/ worktree (default: origin/main)
+  wt rm <name> [--keep-branch]  Remove worktree and delete local branch
+  wt cd <name>                  Enter a worktree by directory name
+  wt path <name>                Show path to a worktree
+  wt prune                      Clean up stale worktree references
+  wt help                       Show this help
+
+Requires a bare-clone layout created by 'git clone-bare-for-worktrees'.
+All worktrees are siblings of .bare/ in the project root.
+EOF
+}
+
+# Hidden subcommand for zsh completions to get the project root.
+cmd__root() {
+    require_bare_layout
+}
+
+main() {
     if [ $# -eq 0 ]; then
         cmd_list
         exit 0
@@ -224,30 +198,19 @@ main() {
     shift
 
     case "$subcommand" in
-        add)
-            cmd_add "$@"
-            ;;
-        ls)
-            cmd_list "$@"
-            ;;
-        rm)
-            cmd_remove "$@"
-            ;;
-        prune)
-            cmd_prune "$@"
-            ;;
-        path)
-            cmd_path "$@"
-            ;;
-        cd)
-            cmd_cd "$@"
-            ;;
-        -h|--help|help)
-            sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
-            ;;
+        main)           cmd_main "$@" ;;
+        add)            cmd_add "$@" ;;
+        rm)             cmd_rm "$@" ;;
+        ls)             cmd_list "$@" ;;
+        cd)             cmd_cd "$@" ;;
+        path)           cmd_path "$@" ;;
+        prune)          cmd_prune "$@" ;;
+        _root)          cmd__root ;;
+        -h|--help|help) cmd_help ;;
         *)
-            # Pass through to git worktree
-            git worktree "$subcommand" "$@"
+            echo "Unknown command: $subcommand" >&2
+            echo "Run 'wt help' for usage." >&2
+            exit 1
             ;;
     esac
 }

--- a/bin/wt
+++ b/bin/wt
@@ -40,14 +40,25 @@ require_bare_layout() {
     echo "$root"
 }
 
+validate_name() {
+    local name="$1"
+    if [[ "$name" == *".."* ]] || [[ "$name" == "/"* ]]; then
+        echo "Error: Invalid worktree name '$name'" >&2
+        exit 1
+    fi
+}
+
 cmd_main() {
     local root
     root=$(require_bare_layout)
     local worktree_dir="$root/main"
 
     if [ ! -d "$worktree_dir" ]; then
-        git -C "$root" worktree add main main 2>/dev/null \
-            || git -C "$root" worktree add main
+        if git -C "$root" show-ref --verify --quiet "refs/heads/main"; then
+            git -C "$root" worktree add main main
+        else
+            git -C "$root" worktree add main
+        fi
     fi
 
     echo "$worktree_dir"
@@ -62,6 +73,7 @@ cmd_add() {
     local name="$1"
     shift
     local start_point="${1:-origin/main}"
+    validate_name "$name"
 
     local root
     root=$(require_bare_layout)
@@ -101,6 +113,8 @@ cmd_rm() {
         exit 1
     fi
 
+    validate_name "$name"
+
     if [ "$name" = "main" ]; then
         echo "Error: Cannot remove persistent worktree 'main'." >&2
         exit 1
@@ -135,6 +149,7 @@ cmd_cd() {
     fi
 
     local name="$1"
+    validate_name "$name"
     local root
     root=$(require_bare_layout)
     local worktree_dir="$root/$name"

--- a/claude/skills/bare-worktrees/SKILL.md
+++ b/claude/skills/bare-worktrees/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: bare-worktrees
+description: >-
+  This skill should be used when the user asks to "clone a repo", "set up
+  worktrees", "create a worktree", "switch worktrees", "add a worktree",
+  "remove a worktree", or mentions bare-clone layouts, the wt command, or
+  git clone-bare-for-worktrees. Provides the bare-clone worktree workflow
+  using the wt CLI and git cb alias.
+---
+
+# Bare-Clone Worktree Workflow
+
+Manage git worktrees using a bare-clone layout where all worktrees are
+sibling directories of `.bare/`.
+
+## When to Use
+
+Use this workflow for **all new clones** and any project that needs parallel
+branch work. This replaces the older `.worktrees/` subdirectory pattern.
+
+Skip for repos that already use the `.worktrees/` pattern — those continue
+to work but are not the preferred layout for new projects.
+
+## Layout
+
+A bare-clone project looks like this:
+
+```text
+~/code/my-project/
+  .bare/          # bare Git repository (all objects, refs, config)
+  .git            # pointer file containing: gitdir: ./.bare
+  main/           # persistent worktree for the trunk branch
+  feature-x/      # temporary worktree (created via wt add)
+  bugfix-y/       # another temporary worktree
+```
+
+Key properties:
+
+- `.bare/` holds the actual git data (no working copy)
+- `.git` is a **file** (not a directory) pointing to `.bare`
+- Each worktree is a **sibling directory** at the project root
+- The `main/` worktree is persistent and protected from deletion
+
+## Cloning a New Project
+
+Use `git cb` (alias for `clone-bare-for-worktrees`):
+
+```bash
+git cb https://github.com/owner/repo.git
+# Creates: repo/.bare, repo/.git, repo/main/
+cd repo/main
+```
+
+With a custom directory name:
+
+```bash
+git cb https://github.com/owner/repo.git my-project
+cd my-project/main
+```
+
+The clone script validates the project name, sets up fetch refspecs for
+bare repos, fetches all remote branches, and creates the initial `main/`
+worktree.
+
+## The wt CLI
+
+`wt` is the primary tool for managing worktrees in bare-clone layouts.
+A zsh wrapper intercepts `main`, `add`, and `cd` subcommands to auto-cd
+into the resulting worktree directory.
+
+### Commands
+
+| Command | Effect |
+|---------|--------|
+| `wt` or `wt ls` | List all worktrees |
+| `wt main` | cd into `main/` (creates if missing) |
+| `wt add <name> [<start-point>]` | Create worktree and cd into it |
+| `wt rm <name> [--keep-branch]` | Remove worktree + delete local branch |
+| `wt cd <name>` | cd into an existing worktree |
+| `wt path <name>` | Print path without cd |
+| `wt prune` | Clean up stale worktree references |
+| `wt help` | Show help |
+
+### Common Patterns
+
+**Start work on a new feature:**
+
+```bash
+wt add my-feature          # creates branch from origin/main, cd's in
+```
+
+**Check out an existing remote branch:**
+
+```bash
+wt add fix-bug             # detects origin/fix-bug, checks it out
+```
+
+**Branch from a specific point:**
+
+```bash
+wt add experiment v2.0.0   # creates branch from tag v2.0.0
+```
+
+**Return to main after feature work:**
+
+```bash
+wt main
+```
+
+**Clean up after merging:**
+
+```bash
+wt rm my-feature           # removes worktree + deletes local branch
+```
+
+**Keep the branch but remove the worktree:**
+
+```bash
+wt rm my-feature --keep-branch
+```
+
+## Detecting the Layout
+
+`wt` detects bare-clone layouts by walking up from the current directory
+looking for a `.bare/` directory alongside a `.git` pointer file. If not
+found, it exits with an error directing the user to `git cb`.
+
+When writing scripts or tools that interact with bare-clone repos:
+
+```bash
+# Check if inside a bare-clone layout
+if [ -d ".bare" ] && [ -f ".git" ]; then
+    # bare-clone root
+elif [ -f ".git" ]; then
+    # possibly inside a worktree — walk up to find .bare
+fi
+```
+
+## Differences from .worktrees/ Pattern
+
+| Aspect | `.worktrees/` (old) | Bare-clone (current) |
+|--------|---------------------|----------------------|
+| Repo type | Normal clone | Bare clone in `.bare/` |
+| Worktree location | `.worktrees/<branch>` | `<root>/<branch>` |
+| Needs .gitignore | Yes (`.worktrees/` entry) | No (worktrees are outside tracked tree) |
+| Main branch | In repo root | In `main/` sibling directory |
+| Clone command | `git clone` | `git cb` |
+| Management tool | `wt` (old version) | `wt` (current version) |
+
+## Safety
+
+- `wt rm main` is blocked — the main worktree is persistent
+- Worktree names are validated against path traversal (`..`, leading `/`)
+- `git cb` validates project names (alphanumeric, dots, hyphens, underscores)
+- `wt rm` deletes the local branch by default; use `--keep-branch` to preserve it
+
+## Integration with Other Skills
+
+When the superpowers or rpikit worktree skills offer to create a
+`.worktrees/` directory, **prefer the bare-clone layout instead** if the
+project was cloned with `git cb`. Check for `.bare/` at the project root
+to determine which layout is in use.
+
+For projects already using `.worktrees/`, continue with that pattern.
+Do not mix layouts within a single project.

--- a/git/config
+++ b/git/config
@@ -59,7 +59,8 @@
 
 	amend = commit --amend
 	amend-noe = commit --amend --no-edit
-	cl = clone-bare-for-worktrees
+	cb = clone-bare-for-worktrees
+	cl = clone
 	ci = commit
 	cm = commit -m
 	aic = !git-ai-commit

--- a/git/config
+++ b/git/config
@@ -59,7 +59,7 @@
 
 	amend = commit --amend
 	amend-noe = commit --amend --no-edit
-	cl = clone
+	cl = clone-bare-for-worktrees
 	ci = commit
 	cm = commit -m
 	aic = !git-ai-commit

--- a/git/ignore
+++ b/git/ignore
@@ -14,10 +14,9 @@ Thumbs.db
 .vscode/
 .lsp/
 
-# Progamming #
+# Programming #
 ##############
 scratch*
-.worktrees/
 .envrc
 
 **/.claude/settings.local.json

--- a/git/ignore
+++ b/git/ignore
@@ -17,6 +17,7 @@ Thumbs.db
 # Programming #
 ##############
 scratch*
+.worktrees/
 .envrc
 
 **/.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Rewrite `bin/wt` for bare-clone worktree layouts where all worktrees are siblings of `.bare/`
- Add `wt main` subcommand for lazy-creating the main worktree
- Update zsh wrapper to intercept `main|add|cd` for auto-cd
- Point `git cl` alias to `clone-bare-for-worktrees`
- Harden `git-clone-bare-for-worktrees` with input validation and strict error handling

## Test plan

- [x] `shellcheck bin/wt` — no warnings
- [x] `shellcheck bin/git-clone-bare-for-worktrees` — no warnings
- [x] `zsh -n zsh/bostonaholic.plugin.zsh` — clean parse
- [x] Manual: `git cl <url>` creates bare-clone layout
- [x] Manual: `wt main`, `wt add`, `wt cd`, `wt rm` work as expected