### PR TITLE
feat(skills): add rebase-open-prs skill (notification-resilient)

### DIFF
--- a/agents/skills/rebase-open-prs/SKILL.md
+++ b/agents/skills/rebase-open-prs/SKILL.md
@@ -26,6 +26,13 @@ fighting over a shared index.
 - **Reuse, then clean up what you created.** If a worktree already exists for the
   branch, use it and leave it in place. Only remove worktrees this run created.
   Never delete the remote branch — only the local worktree and local branch.
+- **Ground truth over notifications.** A PR's outcome is authoritatively
+  observable on the git remote and in its on-disk result file — never inferred
+  from whether an agent's completion notification arrived. Notifications are an
+  optimization; their absence means *reconcile*, not *stall*.
+- **Never tail agent `.output` files.** They are full JSONL transcripts and will
+  overflow the orchestrator's context. Verify outcomes ONLY via git remote state
+  (`reconcile.sh`) or the per-PR result JSON — never by reading agent transcripts.
 
 ## Workflow
 
@@ -74,15 +81,48 @@ without a clear go-ahead.
 Spawn one subagent per rebaseable PR (Task/Agent tool, `general-purpose`). Cap
 concurrency at ~4–6 at a time and batch the rest, so resolution stays careful and
 the machine stays responsive. Give each agent its PR number, branch, and base,
-and the **exact per-PR procedure** below plus a pointer to
-`references/conflict-resolution.md`.
+the shared `$RUN_DIR` (below), and the **exact per-PR procedure** below plus a
+pointer to `references/conflict-resolution.md`.
+
+#### Before dispatching: durable run dir + pre-rebase OID manifest
+
+Agents work in isolated worktrees, so the run directory MUST be a shared,
+absolute path that lives *outside* every worktree — anchor it at the git common
+dir (the single `.git` shared by all worktrees). A relative path like
+`.rebase-run/` is a trap: it resolves inside each agent's own worktree and gets
+deleted by cleanup. Derive `$RUN_DIR` once and hand the absolute value to every
+agent:
+
+```bash
+RUN_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/rebase-run"
+rm -rf "$RUN_DIR" && mkdir -p "$RUN_DIR"      # clear any stale prior-run files
+: > "$RUN_DIR/manifest.tsv"
+```
+
+Capture each rebaseable PR's PRE-REBASE remote OID into the manifest — one
+TAB-separated line `pr⇥branch⇥base⇥pre_oid`. This baseline makes later
+verification mechanical (OID changed + base now an ancestor ⇒ rebased+pushed;
+OID unchanged ⇒ not pushed):
+
+```bash
+# for each rebaseable PR's pr/branch/base from step 2 (origin/* is current after preflight):
+if oid=$(git rev-parse --verify --quiet "origin/$branch^{commit}"); then
+  printf '%s\t%s\t%s\t%s\n' "$pr" "$branch" "$base" "$oid" >> "$RUN_DIR/manifest.tsv"
+else
+  echo "skip PR #$pr — branch $branch not found on origin" >&2   # vanished at dispatch
+fi
+```
+
+Guard the OID lookup with `--verify --quiet`: a bare `git rev-parse "origin/$ghost"`
+prints the literal string back and exits non-zero, which would write a non-OID
+`pre_oid` and make that branch read `OID_CHANGED=yes` forever.
 
 #### Per-PR procedure (hand this to each agent)
 
 ```text
-You own PR #<n>, branch <branch>, base <base>. Work ONLY inside your worktree
-via `git -C "$WT" ...`. Read ~/.claude/skills/rebase-open-prs/references/
-conflict-resolution.md before resolving anything.
+You own PR #<n>, branch <branch>, base <base>. RUN_DIR=<absolute run dir>.
+Work ONLY inside your worktree via `git -C "$WT" ...`. Read ~/.claude/skills/
+rebase-open-prs/references/conflict-resolution.md before resolving anything.
 
 1. Prepare an isolated worktree (reuses one if it already exists):
      eval "$(~/.claude/skills/rebase-open-prs/scripts/prepare-worktree.sh <branch>)"
@@ -92,29 +132,106 @@ conflict-resolution.md before resolving anything.
    resolve each with real understanding (ours = base, theirs = the PR's change),
    stage, `GIT_EDITOR=true git -C "$WT" rebase --continue`, repeat.
    If a conflict needs a product decision or confidence is low: STOP, leave the
-   PR un-pushed, and report it for human review.
+   PR un-pushed, and record status conflicts-flagged in step 7.
 4. If the rebase made no change (already up to date) or emptied the PR: skip the
-   push and report which case.
+   push and record which case in step 7.
 5. Verify (only if conflicts were resolved and a fast check exists): typecheck/
    lint/most-relevant test. Fix resolution-caused failures.
 6. Push: `git -C "$WT" push --force-with-lease origin <branch>`.
-   On stale-lease or permission rejection: do NOT force — report it.
-7. Clean up (run from the main repo, not inside the worktree):
+   On stale-lease or permission rejection: do NOT force — record push-rejected.
+7. PERSIST THE RESULT — do this ALWAYS (even on flag/failure) and BEFORE
+   cleanup or returning. Write valid JSON to the SHARED $RUN_DIR (never inside
+   $WT — step 8 deletes it). This file, not the returned message, is the system
+   of record:
+     jq -n --argjson pr <n> --arg branch "<branch>" --arg base "<base>" \
+       --arg status "<pushed|already-up-to-date|conflicts-flagged|push-rejected|skipped|error>" \
+       --argjson conflicts <files-resolved-count> \
+       --arg verify "<passed|skipped|failed(reason)>" --arg created "$CREATED" \
+       --arg head "$(git -C "$WT" rev-parse HEAD 2>/dev/null || echo unknown)" \
+       --arg note "<one line>" \
+       '{pr:$pr,branch:$branch,base:$base,status:$status,conflicts:$conflicts,
+         verify:$verify,worktree:(if $created=="true" then "created" else "reused" end),
+         head:$head,note:$note}' \
+       > "$RUN_DIR/<n>.json"
+8. Clean up (run from the main repo, not inside the worktree):
      ~/.claude/skills/rebase-open-prs/scripts/cleanup-worktree.sh "$WT" <branch> "$CREATED"
    (no-op for reused worktrees; removes only what step 1 created).
-8. Return the structured result described in the reference.
+9. Returning a structured message is a convenience — if the harness drops it,
+   the orchestrator still recovers your outcome from $RUN_DIR/<n>.json + git.
 ```
 
-### 5. Aggregate and report
+### 5. Reconcile against ground truth, then report
 
-Collect every agent's result into a summary table — include every PR, including
-skipped, flagged, and failed ones:
+Do NOT decide a PR is done because a notification arrived, and do NOT wait on
+notifications indefinitely — they are dropped sometimes. The git remote and the
+on-disk result files are the system of record. Reconciliation is **mandatory**
+before reporting, and it is independent of notifications.
+
+Run reconciliation (read-only and idempotent — safe to re-run while agents are
+still finishing):
+
+```bash
+"$SK/reconcile.sh" "$RUN_DIR/manifest.tsv"
+```
+
+For each dispatched PR, combine its reconcile line with `$RUN_DIR/<pr>.json` and
+derive status from THAT — never from notification presence. Two precedence rules
+resolve every case and keep failures loud:
+
+- **The result file owns the agent's action; git owns remote truth.** A terminal
+  failure status in the file (`conflicts-flagged`, `push-rejected`, `error`,
+  `skipped`) is authoritative — git showing the branch contains base does NOT
+  upgrade it to `pushed` (the branch may already have contained base, e.g. via an
+  earlier merge). Report the file's status.
+- **Any disagreement is surfaced, never silently resolved.** When git contradicts
+  the file (a claimed `pushed` not reflected on the remote; a remote move the file
+  didn't claim), report **`needs-review`** with both signals — do not guess.
+
+Result file present:
+
+| result file `status` | expected reconcile | derived status |
+| -------------------- | ------------------ | -------------- |
+| `pushed` | `REBASED=yes OID_CHANGED=yes` | **pushed** (confirmed by git, notification or not) |
+| `pushed` | anything else | **needs-review** (claimed push not on remote) |
+| `already-up-to-date` | `REBASED=yes OID_CHANGED=no` | **already-up-to-date** |
+| `conflicts-flagged`/`push-rejected`/`error`/`skipped` | any | **take the file's status** (append `needs-review` only if `OID_CHANGED=yes` — remote moved unexpectedly) |
+
+Result file missing (agent died before persisting — fall back to git alone):
+
+| reconcile signal | derived status |
+| ---------------- | -------------- |
+| `REBASED=yes OID_CHANGED=yes` | **pushed** (push is real; agent died after) |
+| `REBASED=yes OID_CHANGED=no` | **already-up-to-date** |
+| `REBASED=no OID_CHANGED=yes` | **needs-review** (pushed but base not contained — wrong/stale base, or origin/base advanced after the agent fetched) |
+| `REBASED=no OID_CHANGED=no` | **in-progress / died** — probe liveness (below) |
+
+Independent of the result file: `CURRENT_OID=missing` ⇒ **branch-gone**
+(merged/closed during the run); `REBASED=base-missing` ⇒ **needs-review** (the
+PR's base branch no longer exists — an orphaned stacked PR).
+
+**Bounded wait + liveness probe.** After dispatching a batch, give agents time to
+work, then reconcile — do not block on a notification that may never arrive. For a
+PR still showing no result file and no remote change, probe that agent with
+`SendMessage`: a reply of **"had no active task"** means it has already come to
+rest (done, not hung) — trust git/result files and stop waiting. A live agent
+means give it longer, then reconcile again. **Bound the probe**: retry at most ~3
+times (a few minutes total); if a PR still has no result file, no remote change,
+and the agent never returns "had no active task", declare it **`error` (agent
+unresponsive — verify manually)** and move on. Never loop forever — that is the
+stall this whole design exists to prevent.
+
+Then produce the summary table (every PR — including skipped, flagged, failed,
+needs-review, and branch-gone):
 
 | PR | Branch | Status | Conflicts | Verify | Worktree | Note |
 | -- | ------ | ------ | --------- | ------ | -------- | ---- |
 
 Statuses: `pushed`, `already-up-to-date`, `conflicts-flagged`, `push-rejected`,
-`skipped`, `error`. Call out any PR needing human follow-up with its reason.
+`skipped`, `needs-review`, `branch-gone`, `error`. Call out any PR needing human
+follow-up.
+
+Optionally remove `$RUN_DIR` when done — it lives under `.git`, so it never
+pollutes the working tree even if left.
 
 ## Additional resources
 
@@ -128,6 +245,11 @@ Statuses: `pushed`, `already-up-to-date`, `conflicts-flagged`, `push-rejected`,
   `PR_WORKTREE_ROOT`.
 - **`cleanup-worktree.sh <path> <branch> <created>`** — remove the worktree and
   local branch only when this run created them; reused worktrees are left alone.
+- **`reconcile.sh <manifest>`** — the orchestrator's source of truth. Fetches
+  `--prune`, then per dispatched branch emits `PR=… BRANCH=… CURRENT_OID=…
+  REBASED=… OID_CHANGED=… LAST_PUSH=…` so final status is derived from git, not
+  from completion notifications. Consumes the `pr⇥branch⇥base⇥pre_oid` manifest
+  written at dispatch.
 
 ### Reference (`references/`)
 

--- a/agents/skills/rebase-open-prs/SKILL.md
+++ b/agents/skills/rebase-open-prs/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: rebase-open-prs
+description: This skill should be used when the user asks to "rebase all open PRs", "update all PRs with latest main", "make sure every open PR is up to date with main", "sync all open PRs onto main", "rebase all my PRs", or wants to bring every open pull request current with its base branch by rebasing in parallel git worktrees, resolving conflicts with a team of agents, and force-pushing.
+---
+
+# Rebase Open PRs onto Main
+
+Bring every open pull request up to date with the latest base branch. Each PR is
+rebased in its own isolated git worktree by a dedicated agent, conflicts are
+resolved with real understanding of the code, the result is force-pushed with
+`--force-with-lease`, and the worktree is cleaned up afterward. Worktrees give
+each agent a private working tree, so all PRs are processed in parallel without
+fighting over a shared index.
+
+## Iron laws
+
+- **Confirm before executing.** Force-pushing to open PRs is outward-facing and
+  hard to reverse. Always show the PR list and get the go-ahead first.
+- **One worktree per PR, fully isolated.** Every agent operates only via
+  `git -C "$WORKTREE_PATH"`. Never touch the main checkout or another agent's
+  worktree.
+- **`--force-with-lease`, never `--force`.** Preserve the safety net against
+  clobbering concurrent pushes.
+- **Resolve, don't guess.** When a conflict needs a product decision or
+  confidence is low, flag it for a human instead of forcing a bad rebase.
+- **Reuse, then clean up what you created.** If a worktree already exists for the
+  branch, use it and leave it in place. Only remove worktrees this run created.
+  Never delete the remote branch — only the local worktree and local branch.
+
+## Workflow
+
+Seed a todo per numbered step; mark each complete as you go.
+
+Scripts live in this skill's directory. Invoke them from the target repo
+(diagnostics go to stderr; parse the `KEY=VALUE` / JSON on stdout):
+
+```bash
+SK=~/.claude/skills/rebase-open-prs/scripts   # fallback: .claude/skills/...
+```
+
+### 1. Preflight
+
+Confirm the working directory is the target repo and is clean enough to work in.
+Fetch and identify the default branch:
+
+```bash
+git fetch --prune origin
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name   # the "main"
+```
+
+Rebase each PR onto its **own base branch** (`baseRefName`), which is `main` for
+normal PRs. This deliberately avoids breaking PRs stacked on a different base. If
+the user insists every PR retarget `main` regardless, note the override.
+
+### 2. Discover open PRs
+
+```bash
+"$SK/list-prs.sh"            # add --author @me to limit to your PRs
+```
+
+Returns a JSON array. Each item has `rebaseable` and (when skipped) `skipReason`.
+Defaults: drafts included, forks excluded (contributor fork branches usually
+can't be pushed to — pass `--include-forks` only if push access is known).
+
+### 3. Confirm scope with the user
+
+Present the rebaseable PRs (number, branch, base, title, author) and the skipped
+ones with reasons. State plainly: each will be rebased and **force-pushed**.
+Get confirmation, and ask whether to include any skipped drafts. Do not proceed
+without a clear go-ahead.
+
+### 4. Dispatch a team of agents — one per PR
+
+Spawn one subagent per rebaseable PR (Task/Agent tool, `general-purpose`). Cap
+concurrency at ~4–6 at a time and batch the rest, so resolution stays careful and
+the machine stays responsive. Give each agent its PR number, branch, and base,
+and the **exact per-PR procedure** below plus a pointer to
+`references/conflict-resolution.md`.
+
+#### Per-PR procedure (hand this to each agent)
+
+```text
+You own PR #<n>, branch <branch>, base <base>. Work ONLY inside your worktree
+via `git -C "$WT" ...`. Read ~/.claude/skills/rebase-open-prs/references/
+conflict-resolution.md before resolving anything.
+
+1. Prepare an isolated worktree (reuses one if it already exists):
+     eval "$(~/.claude/skills/rebase-open-prs/scripts/prepare-worktree.sh <branch>)"
+   This sets WORKTREE_PATH, CREATED, BRANCH. Use WT="$WORKTREE_PATH".
+2. Rebase: `git -C "$WT" rebase origin/<base>`.
+3. If conflicts: run the rebase loop in the reference — list conflicted files,
+   resolve each with real understanding (ours = base, theirs = the PR's change),
+   stage, `GIT_EDITOR=true git -C "$WT" rebase --continue`, repeat.
+   If a conflict needs a product decision or confidence is low: STOP, leave the
+   PR un-pushed, and report it for human review.
+4. If the rebase made no change (already up to date) or emptied the PR: skip the
+   push and report which case.
+5. Verify (only if conflicts were resolved and a fast check exists): typecheck/
+   lint/most-relevant test. Fix resolution-caused failures.
+6. Push: `git -C "$WT" push --force-with-lease origin <branch>`.
+   On stale-lease or permission rejection: do NOT force — report it.
+7. Clean up (run from the main repo, not inside the worktree):
+     ~/.claude/skills/rebase-open-prs/scripts/cleanup-worktree.sh "$WT" <branch> "$CREATED"
+   (no-op for reused worktrees; removes only what step 1 created).
+8. Return the structured result described in the reference.
+```
+
+### 5. Aggregate and report
+
+Collect every agent's result into a summary table — include every PR, including
+skipped, flagged, and failed ones:
+
+| PR | Branch | Status | Conflicts | Verify | Worktree | Note |
+| -- | ------ | ------ | --------- | ------ | -------- | ---- |
+
+Statuses: `pushed`, `already-up-to-date`, `conflicts-flagged`, `push-rejected`,
+`skipped`, `error`. Call out any PR needing human follow-up with its reason.
+
+## Additional resources
+
+### Scripts (`scripts/`)
+
+- **`list-prs.sh`** — open PRs as JSON, annotated with `rebaseable`/`skipReason`
+  (`--author`, `--include-forks`, `--skip-drafts`, `--limit`).
+- **`prepare-worktree.sh <branch>`** — find-or-create an isolated worktree;
+  prints `WORKTREE_PATH`, `CREATED`, `BRANCH`. Reuses any existing worktree for
+  the branch (including `wt`-created ones). Override location with
+  `PR_WORKTREE_ROOT`.
+- **`cleanup-worktree.sh <path> <branch> <created>`** — remove the worktree and
+  local branch only when this run created them; reused worktrees are left alone.
+
+### Reference (`references/`)
+
+- **`conflict-resolution.md`** — the rebase loop, how to resolve conflicts
+  correctly (ours/theirs semantics), file-type-specific handling (lockfiles,
+  generated files, migrations), verification, push rejection handling, and the
+  stop conditions that mean "flag for a human, don't force."

--- a/agents/skills/rebase-open-prs/references/conflict-resolution.md
+++ b/agents/skills/rebase-open-prs/references/conflict-resolution.md
@@ -1,0 +1,123 @@
+# Rebase Conflict Resolution & Edge Cases
+
+Detailed guidance for the per-PR agent. The goal is a correct rebase onto the
+latest base branch — never a fast, destructive one. When a conflict cannot be
+resolved with confidence, stop and report rather than guess.
+
+## The rebase loop
+
+All git commands run against the assigned worktree via `git -C "$WORKTREE_PATH"`.
+Never touch the main checkout or another agent's worktree.
+
+```bash
+git -C "$WT" rebase "origin/$BASE"
+```
+
+If it exits non-zero, a conflict (or other stop) occurred. Drive the loop:
+
+1. List conflicted files: `git -C "$WT" diff --name-only --diff-filter=U`
+2. For each file, open it and resolve every `<<<<<<<` / `=======` / `>>>>>>>`
+   marker (see "How to resolve" below).
+3. Stage resolved files: `git -C "$WT" add <file>`
+4. Continue: `GIT_EDITOR=true git -C "$WT" rebase --continue`
+   (`GIT_EDITOR=true` accepts the existing commit message non-interactively.)
+5. Repeat until the rebase completes or a stop condition below is hit.
+
+Never run `git rebase --skip` to make conflicts disappear — it silently drops
+the PR's commit. Use it only when a commit is genuinely empty because its change
+already landed in base (git will say "patch is empty").
+
+## How to resolve a conflict correctly
+
+A rebase replays the PR's commits on top of new base code. In each conflict:
+
+- **`ours` (`<<<<<<< HEAD`)** is the base branch's version (already on main).
+- **`theirs` (`>>>>>>> <commit>`)** is the PR's change being replayed.
+
+This is the reverse of a merge — do not blindly keep one side.
+
+Principles:
+
+- **Preserve the PR's intent.** The PR exists to make a change; keep it, adapted
+  to the new base. Re-apply the PR's logic on top of base's refactors.
+- **Keep both when both are additive.** Two new functions, two new imports, two
+  list entries — usually both belong. Merge them, don't choose.
+- **Understand before editing.** Read enough surrounding code to know what each
+  side does. A conflict in a lockfile, generated file, or migration is resolved
+  differently than one in business logic (see below).
+- **Match surrounding style** — imports ordering, formatting, naming.
+- After resolving, re-read the whole hunk to confirm it compiles logically (no
+  leftover markers, no duplicated declarations, no half-merged statements).
+
+## File-type-specific handling
+
+- **Lockfiles** (`package-lock.json`, `yarn.lock`, `Cargo.lock`, `Gemfile.lock`,
+  `poetry.lock`): do not hand-merge. Take base's version, finish the rebase, then
+  regenerate (`npm install`, `bundle lock`, `cargo build`, etc.) and amend.
+- **Generated files / snapshots**: regenerate from source rather than merging.
+- **Migrations / ordered sequences**: keep both, but verify ordering/IDs/
+  timestamps don't collide; renumber the PR's entry to come after base's.
+- **`CHANGELOG.md`**: keep both entries; place the PR's under the right heading.
+- **Imports / dependency manifests**: union both sides, then de-duplicate.
+
+## Verify before pushing
+
+A clean rebase (no conflicts) is low-risk — push directly.
+
+If conflicts were resolved, do a lightweight sanity check before force-pushing,
+when a fast one is available in the repo (do not run full slow suites across
+every PR):
+
+- Typecheck / compile (e.g. `tsc --noEmit`, `go build ./...`, `cargo check`).
+- Linter on changed files.
+- The single most relevant fast test, if obvious.
+
+If the check fails because of the resolution, fix it. If it fails for unrelated
+pre-existing reasons, note it and proceed.
+
+## Pushing
+
+```bash
+git -C "$WT" push --force-with-lease origin "$BRANCH"
+```
+
+`--force-with-lease` refuses to overwrite if the remote branch advanced since the
+last fetch — a safety net against clobbering someone else's push. Never downgrade
+to plain `--force`.
+
+If the push is rejected:
+
+- **stale lease / remote moved**: someone pushed to the PR branch. Do NOT
+  force. Report it for human review.
+- **protected branch / permission denied**: report; cannot push.
+
+## Stop conditions — report, don't force
+
+Abort the PR (leave it un-pushed, run cleanup only if this run created the
+worktree) and report when:
+
+- A conflict requires a **product/semantic decision** (two incompatible
+  intents), not a mechanical merge.
+- Resolution confidence is **low** — guessing risks shipping broken code to an
+  open PR.
+- The rebase **empties the PR** (all commits already in base) — the PR is
+  effectively merged; suggest closing instead.
+- The PR's base branch **no longer exists** or the branch is **already current**
+  with base (nothing to do — report "already up to date", skip the push).
+- Tests/typecheck fail **because of** the resolution and the fix isn't obvious.
+
+Surface these clearly with the affected files and a one-line reason. Per the
+fail-loud principle, a flagged PR a human can finish beats a forced bad rebase.
+
+## Per-PR result contract
+
+Return a compact structured result to the orchestrator:
+
+```text
+PR #<n> (<branch>)
+status: pushed | already-up-to-date | conflicts-flagged | push-rejected | skipped | error
+conflicts: <count of files resolved>
+verify: passed | skipped | failed(<why>)
+worktree: created|reused, cleaned-up: yes|no
+note: <one line — e.g. which files needed judgment, why flagged>
+```

--- a/agents/skills/rebase-open-prs/references/conflict-resolution.md
+++ b/agents/skills/rebase-open-prs/references/conflict-resolution.md
@@ -111,13 +111,18 @@ fail-loud principle, a flagged PR a human can finish beats a forced bad rebase.
 
 ## Per-PR result contract
 
-Return a compact structured result to the orchestrator:
+**The durable result file is the system of record — not the returned message.**
+Before cleanup and before returning, ALWAYS write `$RUN_DIR/<pr>.json` (valid
+JSON via `jq -n`, per step 7 of the per-PR procedure) to the shared run dir the
+orchestrator passed in — never inside the worktree, which cleanup deletes. The
+orchestrator reconciles outcomes from this file plus git remote state, so a
+dropped completion notification never loses your work.
 
-```text
-PR #<n> (<branch>)
-status: pushed | already-up-to-date | conflicts-flagged | push-rejected | skipped | error
-conflicts: <count of files resolved>
-verify: passed | skipped | failed(<why>)
-worktree: created|reused, cleaned-up: yes|no
-note: <one line — e.g. which files needed judgment, why flagged>
-```
+JSON fields: `pr`, `branch`, `base`, `status`, `conflicts` (count of files
+resolved), `verify` (`passed|skipped|failed(why)`), `worktree`
+(`created|reused`), `head` (post-rebase HEAD OID), `note` (one line — e.g.
+which files needed judgment, why flagged). `status` is one of:
+`pushed | already-up-to-date | conflicts-flagged | push-rejected | skipped | error`.
+
+Returning the same summary as a message is a convenience for the orchestrator's
+live view; if the harness drops it, reconciliation still recovers the outcome.

--- a/agents/skills/rebase-open-prs/scripts/cleanup-worktree.sh
+++ b/agents/skills/rebase-open-prs/scripts/cleanup-worktree.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cleanup-worktree.sh — remove a worktree and local branch created for a rebase.
+#
+# Usage: cleanup-worktree.sh <worktree-path> <branch> <created-flag>
+#
+# Run this from the MAIN repo checkout, not from inside the worktree being
+# removed. Only worktrees this skill created (created-flag=true) are removed;
+# pre-existing/reused worktrees are left untouched. The REMOTE PR branch is
+# never deleted — only the local worktree and local branch are cleaned up.
+
+worktree_path="${1:?usage: cleanup-worktree.sh <path> <branch> <created>}"
+branch="${2:?missing branch}"
+created="${3:?missing created flag}"
+
+if [ "$created" != "true" ]; then
+  echo "Reused pre-existing worktree at $worktree_path — leaving it in place." >&2
+  exit 0
+fi
+
+git worktree remove --force "$worktree_path" 2>/dev/null || true
+git worktree prune >/dev/null 2>&1 || true
+# Delete the local branch only; the remote branch backing the PR is untouched.
+git branch -D "$branch" >/dev/null 2>&1 || true
+
+echo "Cleaned up worktree $worktree_path and local branch $branch." >&2

--- a/agents/skills/rebase-open-prs/scripts/list-prs.sh
+++ b/agents/skills/rebase-open-prs/scripts/list-prs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# list-prs.sh — list open PRs that are candidates for rebasing onto their base.
+#
+# Usage:
+#   list-prs.sh [--author <user|@me>] [--include-forks] [--skip-drafts] [--limit N]
+#
+# Defaults: drafts are INCLUDED (they are open PRs), forks are EXCLUDED
+# (contributor fork branches usually cannot be pushed to).
+#
+# Output (stdout): JSON array. Each element:
+#   { number, title, headRefName, baseRefName, isDraft, isCrossRepository,
+#     mergeStateStatus, author, url, rebaseable, skipReason }
+# Run filtered downstream on `.rebaseable == true`. Diagnostics go to stderr.
+
+include_forks=false
+skip_drafts=false
+author=""
+limit=200
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --include-forks) include_forks=true; shift ;;
+    --skip-drafts)   skip_drafts=true;   shift ;;
+    --author)        author="$2";        shift 2 ;;
+    --limit)         limit="$2";         shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+fields="number,title,headRefName,baseRefName,isDraft,isCrossRepository,mergeStateStatus,author,url"
+args=(pr list --state open --limit "$limit" --json "$fields")
+[ -n "$author" ] && args+=(--author "$author")
+
+raw=$(gh "${args[@]}")
+
+result=$(echo "$raw" | jq \
+  --argjson incForks "$include_forks" \
+  --argjson skipDrafts "$skip_drafts" '
+  map(
+    (if   .isCrossRepository and ($incForks   | not) then "fork (cannot push to contributor branch)"
+     elif .isDraft           and ($skipDrafts)       then "draft (skipped by request)"
+     else null end) as $skip
+    | .author = (.author.login // .author)
+    | . + { rebaseable: ($skip == null), skipReason: $skip }
+  )')
+
+# Human-readable summary to stderr.
+total=$(echo "$result" | jq 'length')
+ok=$(echo "$result" | jq '[.[] | select(.rebaseable)] | length')
+echo "Found $total open PR(s); $ok rebaseable, $((total - ok)) skipped." >&2
+
+echo "$result"

--- a/agents/skills/rebase-open-prs/scripts/prepare-worktree.sh
+++ b/agents/skills/rebase-open-prs/scripts/prepare-worktree.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare-worktree.sh — find or create an isolated worktree for a PR branch.
+#
+# Usage: prepare-worktree.sh <branch>
+#
+# Reuses an existing worktree if the branch is already checked out in one
+# (including worktrees created by other tools such as `wt`). Otherwise creates
+# a fresh worktree under $PR_WORKTREE_ROOT (default: a hidden sibling dir of
+# the repo, ".pr-rebase-worktrees").
+#
+# Output (stdout), one KEY=VALUE per line — parse these, ignore everything else:
+#   WORKTREE_PATH=<absolute path>
+#   CREATED=true|false        # true only when this run created the worktree
+#   BRANCH=<branch>
+#
+# CREATED governs cleanup: only worktrees this run created should be removed.
+
+branch="${1:?usage: prepare-worktree.sh <branch>}"
+
+repo_root=$(git rev-parse --show-toplevel)
+worktree_root="${PR_WORKTREE_ROOT:-$(dirname "$repo_root")/.pr-rebase-worktrees}"
+sanitized=${branch//\//-}
+target="$worktree_root/$sanitized"
+
+# Get the latest remote state so the rebase target and branch tip are current.
+git fetch --quiet origin || true
+
+# Reuse if the branch is already checked out in ANY worktree of this repo.
+existing=$(git worktree list --porcelain | awk -v b="refs/heads/$branch" '
+  $1=="worktree"{p=substr($0, index($0,$2))}
+  $1=="branch" && $2==b {print p}
+')
+
+if [ -n "$existing" ]; then
+  echo "Reusing existing worktree for '$branch' at $existing" >&2
+  echo "WORKTREE_PATH=$existing"
+  echo "CREATED=false"
+  echo "BRANCH=$branch"
+  exit 0
+fi
+
+mkdir -p "$worktree_root"
+
+# Create the worktree from the local branch if present, else from origin.
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git worktree add "$target" "$branch" >&2
+else
+  git worktree add -b "$branch" "$target" "origin/$branch" >&2
+fi
+
+# Best-effort upstream so a later plain `git push` targets origin/<branch>.
+git -C "$target" branch --set-upstream-to="origin/$branch" "$branch" >/dev/null 2>&1 || true
+
+echo "WORKTREE_PATH=$target"
+echo "CREATED=true"
+echo "BRANCH=$branch"

--- a/agents/skills/rebase-open-prs/scripts/reconcile.sh
+++ b/agents/skills/rebase-open-prs/scripts/reconcile.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# reconcile.sh — determine the TRUE outcome of a rebase-open-prs run from git,
+# independent of any agent completion notification. This is the orchestrator's
+# source of truth: a PR is "done" because the remote says so, not because a
+# notification arrived.
+#
+# Usage: reconcile.sh <manifest>
+#
+# The manifest is a TAB-separated file, one dispatched PR per line, captured at
+# dispatch time (BEFORE any agent ran):
+#     <pr>\t<branch>\t<base>\t<pre_rebase_oid>
+#
+# Fetches the remote (--prune), then for every manifest line emits ONE
+# machine-parseable line to stdout:
+#     PR=<n> BRANCH=<branch> CURRENT_OID=<oid|missing> REBASED=yes|no|base-missing \
+#       OID_CHANGED=yes|no LAST_PUSH=<relative>
+# where, per branch:
+#   REBASED      yes/no = origin/<base> is now an ancestor of origin/<branch>
+#                (rebase landed); base-missing = origin/<base> no longer exists
+#                (e.g. a stacked PR whose base was deleted/merged) — flag it, do
+#                NOT collapse it into "not rebased".
+#   OID_CHANGED  origin/<branch> tip differs from the manifest pre-rebase OID (a push happened)
+#   LAST_PUSH    committer-date-relative of the branch tip. A rebase rewrites the
+#                committer date, so this approximates when the push happened; for
+#                an already-up-to-date branch that was never re-committed it
+#                reflects the original commit time. LAST_PUSH is the LAST field
+#                and may contain spaces — parse it as everything after "LAST_PUSH=".
+# Diagnostics go to stderr; only the data lines go to stdout.
+
+manifest="${1:?usage: reconcile.sh <manifest>}"
+[ -f "$manifest" ] || { echo "manifest not found: $manifest" >&2; exit 2; }
+
+echo "Fetching latest remote state…" >&2
+git fetch --prune origin >/dev/null 2>&1 \
+  || echo "warning: git fetch failed; reporting from local remote-tracking refs" >&2
+
+total=0
+rebased_count=0
+
+while IFS=$'\t' read -r pr branch base pre_oid || [ -n "${pr:-}" ]; do
+  if [ -z "${pr// /}" ]; then continue; fi      # skip blank lines
+  case "$pr" in \#*) continue ;; esac           # skip comments
+  total=$((total + 1))
+
+  ref="refs/remotes/origin/$branch"
+  if ! current_oid=$(git rev-parse --verify --quiet "${ref}^{commit}"); then
+    echo "PR=$pr BRANCH=$branch CURRENT_OID=missing REBASED=no OID_CHANGED=no LAST_PUSH=gone"
+    echo "  $branch not found on origin (deleted/merged during the run?)" >&2
+    continue
+  fi
+
+  base_ref="refs/remotes/origin/$base"
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    rebased="base-missing"
+    echo "  base $base for $branch not found on origin (deleted/merged stacked base?)" >&2
+  elif git merge-base --is-ancestor "$base_ref" "$ref"; then
+    rebased=yes
+    rebased_count=$((rebased_count + 1))
+  else
+    rebased=no
+  fi
+
+  if [ "$current_oid" = "$pre_oid" ]; then oid_changed=no; else oid_changed=yes; fi
+
+  last_push=$(git log -1 --format=%cr "$ref" 2>/dev/null || echo unknown)
+
+  echo "PR=$pr BRANCH=$branch CURRENT_OID=$current_oid REBASED=$rebased OID_CHANGED=$oid_changed LAST_PUSH=$last_push"
+done < "$manifest"
+
+echo "Reconciled $total branch(es); $rebased_count now contain their base." >&2


### PR DESCRIPTION
## Summary

Adds the **`rebase-open-prs`** skill — brings every open PR up to date with its base branch by rebasing each one in an isolated git worktree (a team of agents, one per PR), resolving conflicts with real code understanding, force-pushing with `--force-with-lease`, and cleaning up.

Two commits:

1. **`feat`: the skill** — discover open PRs → confirm scope → dispatch one agent per PR in its own worktree → rebase/resolve/push/cleanup → summary table. Reuses an existing worktree for a branch if present; only removes worktrees it created; never deletes the remote branch.
2. **`fix`: notification resilience** — the orchestrator previously learned "a PR is done" only from each agent's completion notification. When the harness drops those, it stalled forever despite every branch already being pushed. This makes **git remote state + on-disk result files the system of record**, demoting notifications to an optimization.

## How the resilience layer works

- A shared run dir anchored at `git rev-parse --git-common-dir` (identical from the orchestrator and every worktree; survives worktree cleanup).
- A pre-rebase OID manifest (`pr/branch/base/pre_oid`) captured at dispatch.
- Each agent persists `$RUN_DIR/<pr>.json` before cleanup/return.
- `scripts/reconcile.sh`: fetch + per-branch ancestry / oid-changed / last-push; distinguishes a deleted base (`base-missing`) and a gone branch.
- Step 5 reconciliation derives status from a decision table over git + result file — the file owns the agent's action, git owns remote truth, disagreements surface as `needs-review`. The wait is bounded with a terminal fallback.
- Iron law: never tail agent `.output` transcripts.

## Files

- `agents/skills/rebase-open-prs/SKILL.md` — workflow (steps 1–5)
- `agents/skills/rebase-open-prs/scripts/{list-prs,prepare-worktree,cleanup-worktree,reconcile}.sh`
- `agents/skills/rebase-open-prs/references/conflict-resolution.md`

## Test plan

- [x] `shellcheck` passes on all four scripts
- [x] `markdownlint` passes on SKILL.md + reference (repo config)
- [x] `prepare-worktree.sh` / `cleanup-worktree.sh` e2e: create → rebase → reuse → no-op cleanup on reused → remove on created
- [x] `reconcile.sh` e2e classifies rebased / stale / stacked-non-main-base / deleted-on-remote / `REBASED=no OID_CHANGED=yes` / `base-missing` correctly
- [x] Step-7 `jq` result snippet emits valid JSON with correct `worktree: created|reused` mapping
- [x] Adversarial fresh-context review: APPROVE (3 blocking + 4 non-blocking findings resolved, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)